### PR TITLE
feat27: 월 매출 예측 FAST API 구축 및 로컬 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+
+# 예측 모델 파일(saved_sales_models)
+report_pred_api/saved_sales_models/

--- a/Dockerfile.report_pred
+++ b/Dockerfile.report_pred
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY report_pred_api/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY report_pred_api /app/report_pred_api
+
+EXPOSE 8002
+
+CMD ["uvicorn", "report_pred_api.main:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "2"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,11 @@ services:
     ports:
       - "8001:8001"
     restart: always
+
+  report_pred:
+    build:
+      context: ./report_pred_api
+      dockerfile: Dockerfile.report_pred
+    ports:
+      - "8002:8002"
+    restart: always

--- a/report_pred_api/exceptions.py
+++ b/report_pred_api/exceptions.py
@@ -1,0 +1,5 @@
+# 에러 확인용으로 추가했습니다.
+class PredictionError(Exception):
+    def __init__(self, public_message: str):
+        self.public_message = public_message
+        super().__init__(public_message)

--- a/report_pred_api/main.py
+++ b/report_pred_api/main.py
@@ -1,0 +1,44 @@
+import logging
+
+from fastapi import FastAPI, HTTPException
+from .schemas import SalesInput, SalesOutput
+from .sales_predictor import predict_sales
+from .exceptions import PredictionError
+from fastapi.middleware.cors import CORSMiddleware
+
+logging.basicConfig(
+    level=logging.INFO,
+    format = "%(asctime)s %(levelname)s %(name)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="REPORT PRED API",
+    description="sales_per_month pred model FAST_API",
+    version="1.0.0" # 변경 시 docs를 위해 version 변경
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/report_pred/sales/health")
+def health_check():
+    return {"status": "sales_pred_api ok"}
+
+
+@app.post("/report_pred/sales", response_model=SalesOutput)
+def predict_sales_endpoint(data: SalesInput):
+    try:
+        return predict_sales(data)
+    except PredictionError as e:
+        logger.warning("Prediction failed: %s", e.public_message)
+        raise HTTPException(status_code=503, detail=e.public_message)
+    except Exception:
+        logger.exception("Unhandled error in /report_pred/sales")
+        raise HTTPException(status_code=500, detail="서버 내부 오류가 발생했습니다.")

--- a/report_pred_api/requirements.txt
+++ b/report_pred_api/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.135.3
+uvicorn==0.44.0
+lightgbm==4.6.0
+xgboost==3.2.0
+scikit-learn==1.6.1
+pandas==2.2.3
+numpy==2.4.4

--- a/report_pred_api/sales_model_loader.py
+++ b/report_pred_api/sales_model_loader.py
@@ -1,0 +1,74 @@
+import os
+import json
+import pickle
+import lightgbm as lgb
+import xgboost as xgb
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 모델 파일 경로
+# MODEL_DIR = os.path.join(os.path.dirname(__file__), "..", "src", "saved_models")
+MODEL_DIR = os.path.join(os.path.dirname(__file__), "saved_sales_models")
+
+def load_sales_models():
+    """
+    매출 예측 모델 전체 로드
+    반환: {
+        "config": dict,
+        "category_mappings": dict,
+        "kmeans": KMeans,
+        "lgb_clf": lgb.Booster,
+        "lgb_reg": {0: lgb.Booster, 1: ..., 2: ..., 3: ...},
+        "xgb_reg": {0: xgb.Booster, 1: ..., 2: ..., 3: ...},
+    }
+    """
+    try: 
+        # 데이터 담아갈 모델 선언
+        models = {}
+
+        # config
+        with open(os.path.join(MODEL_DIR, "sales_model_config.json"), "r", encoding="utf-8") as f:
+            models["config"] = json.load(f)
+
+        # 카테고리 매핑
+        with open(os.path.join(MODEL_DIR, "sales_category_mappings.json"), "r", encoding="utf-8") as f:
+            raw = json.load(f)
+            # 행정동_코드: 값 → 인덱스 딕셔너리로 변환
+            models["category_mappings"] = {
+                "행정동_코드": {v: i for i, v in enumerate(raw["행정동_코드"])},
+                "서비스_업종_코드": {v: i for i, v in enumerate(raw["서비스_업종_코드"])},
+            }
+
+        # K-Means
+        with open(os.path.join(MODEL_DIR, "kmeans.pkl"), "rb") as f:
+            models["kmeans"] = pickle.load(f)
+
+        # LightGBM 분류 (1단계)
+        models["lgb_clf"] = lgb.Booster(
+            model_file=os.path.join(MODEL_DIR, "lgb_clf.txt")
+        )
+
+        # LightGBM 회귀 (2단계, 구간별)
+        models["lgb_reg"] = {}
+        for seg in range(4):
+            models["lgb_reg"][seg] = lgb.Booster(
+                model_file=os.path.join(MODEL_DIR, f"lgb_reg_{seg}.txt")
+            )
+
+        # XGBoost 회귀 (2단계, 구간별)
+        models["xgb_reg"] = {}
+        for seg in range(4):
+            booster = xgb.Booster()
+            booster.load_model(os.path.join(MODEL_DIR, f"xgb_reg_{seg}.json"))
+            models["xgb_reg"][seg] = booster
+
+        print("매출 예측 모델 로드 완료")
+        return models
+    except Exception:
+        logger.exception("매출 예측 모델 로드 실패")
+        raise
+
+
+# 앱 시작 시 한 번만 로드
+sales_models = load_sales_models()

--- a/report_pred_api/sales_predictor.py
+++ b/report_pred_api/sales_predictor.py
@@ -1,0 +1,164 @@
+import numpy as np
+import pandas as pd
+import xgboost as xgb
+import logging
+
+from .sales_model_loader import sales_models
+from .schemas import SalesInput, SalesOutput
+from .exceptions import PredictionError
+
+# 예외 처리
+logger = logging.getLogger(__name__)
+
+config = sales_models["config"]
+cat_map = sales_models["category_mappings"]
+kmeans = sales_models["kmeans"]
+lgb_clf = sales_models["lgb_clf"]
+lgb_reg = sales_models["lgb_reg"]
+xgb_reg = sales_models["xgb_reg"]
+
+# 소규모 점포 기준: 유사_업종_점포_수 < 4이면 모델 예측 신뢰도 낮음
+# → 학습 시 소규모 점포는 폐업률 노이즈가 심해 제외했던 기준과 동일
+SMALL_STORE_THRESHOLD = config["small_store_threshold"]
+
+# 앙상블 가중치: 학습 시 최적 가중치 탐색 결과
+# → LGB 소프트 0.25 + XGB 0.75 조합이 MdAPE 기준 최적
+LGB_WEIGHT = config["best_w_soft"]       # 0.25
+XGB_WEIGHT = 1 - config["best_w_soft"]  
+
+
+# 전처리 함수
+def _encode_input(data: SalesInput) -> pd.DataFrame:
+    """
+    SalesInput → 모델 입력용 DataFrame 변환
+
+    - 행정동_코드, 서비스_업종_코드를 학습 때 사용한 인덱스로 변환
+      (sales_category_mappings.json 기준)
+    - config["features"] 순서대로 컬럼 정렬
+      (모델은 학습 때와 동일한 피처 순서를 요구함)
+    - 없는 값은 NaN → LightGBM/XGBoost가 NaN 그대로 처리
+    """
+
+    row = data.model_dump()
+
+    # 카테고리 인코딩
+    # 학습 때 {값: 인덱스} 형태로 변환했던 것과 동일하게 적용
+    # 매핑에 없는 값이면 -1 (미등록 행정동/업종)
+    row["행정동_코드"] = cat_map["행정동_코드"].get(row["행정동_코드"], -1)
+    row["서비스_업종_코드"] = cat_map["서비스_업종_코드"].get(row["서비스_업종_코드"], -1)
+
+    # 피처 순서 맞춰서 DataFrame 생성
+    df = pd.DataFrame([row])[config["features"]]
+    
+    # categorical 타입 지정
+    for col in config["cat_cols"]:
+        df[col] = df[col].astype("category")
+    
+    return df
+
+
+# 예측 메인 함수
+def predict_sales(data: SalesInput) -> SalesOutput:
+    """
+    매출 예측 전체 파이프라인
+
+    [흐름]
+    1. 소규모 점포 예외처리
+    2. 입력 전처리
+    3. K-means로 구간 결정
+    4. LGB 소프트 보팅 예측
+    5. XGB 확정 구간 예측
+    6. 앙상블 → expm1 역변환
+    7. 하한/상한 벗어나면 LOW 반환
+    8. 정상이면 HIGH 반환
+    """
+    try:
+        # STEP 1. 소규모 점포 예외처리
+        
+        # 유사_업종_점포_수 < 4이면 통계적으로 불안정
+        # → 모델 예측 없이 바로 LOW 반환
+        if data.유사_업종_점포_수 < SMALL_STORE_THRESHOLD:
+            return SalesOutput(
+                pred_sales=0.0,
+                segment=-1,
+                confidence="LOW",
+                message="점포 수가 적어 예측 신뢰도가 낮습니다."
+            )
+
+        # STEP 2. 입력 전처리
+        X = _encode_input(data)
+
+        # STEP 3. K-means 구간 결정
+        
+        # K-means는 학습 때 log 스케일 매출 기준으로 4구간으로 나눴음
+        # → 예측 시에도 동일하게 log 매출 기준으로 구간 결정
+        # cluster_mapping: K-means 원본 번호 → 우리 구간 번호 (저→고 순서)
+        log_sales = X[["sales_lag1_log"]].fillna(0).values
+        raw_cluster = int(kmeans.predict(log_sales)[0])
+        cluster_mapping = {int(k): v for k, v in config["cluster_mapping"].items()}
+        segment = cluster_mapping.get(raw_cluster, raw_cluster)
+
+        # STEP 4. LightGBM 소프트 보팅 예측
+
+        # lgb_clf: 4개 구간에 속할 확률 반환 (합계 = 1.0)
+        # 소프트 보팅: 각 구간 예측값 × 해당 구간 확률 → 가중합
+        # → 구간 경계 근처일 때 예측값이 급격히 튀지 않도록 완화
+        lgb_proba = lgb_clf.predict(X)[0]  # shape: (4,)
+        lgb_pred_log = sum(
+            lgb_proba[seg] * lgb_reg[seg].predict(X)[0]
+            for seg in range(4)
+        )
+
+        # STEP 5. XGBoost 확정 구간 예측
+    
+        # XGBoost는 K-means로 확정된 구간의 모델만 사용
+        # (소프트 보팅 없이 단일 구간 예측)
+        xgb_input = xgb.DMatrix(X, enable_categorical=True)
+        xgb_pred_log = float(xgb_reg[segment].predict(xgb_input)[0])
+
+        # STEP 6. 앙상블 + 역변환
+        
+        # log 스케일에서 가중 평균 후 expm1으로 원금액 복원
+        # LGB 0.25 + XGB 0.75 (학습 시 최적 가중치)
+        ensemble_log = LGB_WEIGHT * lgb_pred_log + XGB_WEIGHT * xgb_pred_log
+        pred_sales = float(np.expm1(ensemble_log))
+        
+        # STEP 7. 하한/상한 예외처리
+        
+        # 학습 범위 밖 → 모델이 본 적 없는 데이터 → LOW
+        # lower_bound: 100만원 (학습 시 하한 필터 기준)
+        # upper_bound: 374,179,397원 (학습 시 p99.9 상한 필터 기준)
+        if pred_sales < config["lower_bound"]:
+            return SalesOutput(
+                pred_sales=pred_sales,
+                segment=segment,
+                confidence="LOW",
+                message="예측 매출이 너무 낮아(100만원 미만) 신뢰도가 낮습니다."
+            )
+
+        if pred_sales > config["upper_bound"]:
+            return SalesOutput(
+                pred_sales=pred_sales,
+                segment=segment,
+                confidence="LOW",
+                message="고매출 특수상권(4억 이상)으로 예측 신뢰도가 낮습니다."
+            )
+
+        # STEP 8. 정상 반환
+        return SalesOutput(
+            pred_sales=pred_sales,
+            segment=segment,
+            confidence="HIGH",
+            message=None
+        )
+    except PredictionError:
+        raise
+    except KeyError as e:
+        logger.exception("Config or mapping key missing: %s", e)
+        raise PredictionError("모델 설정이 올바르지 않습니다.")
+    except FileNotFoundError as e:
+        logger.exception("Model file missing: %s", e)
+        raise PredictionError("예측 모델 파일을 찾을 수 없습니다.")
+    except Exception:
+        logger.exception("Unexpected error during prediction. input=%s", data.model_dump())
+        raise PredictionError("매출 예측 처리 중 오류가 발생했습니다.")

--- a/report_pred_api/schemas.py
+++ b/report_pred_api/schemas.py
@@ -1,0 +1,51 @@
+from pydantic import BaseModel
+from typing import Optional
+
+# 매출 예측 입력
+class SalesInput(BaseModel):
+    # 모델 feature(.csv 기반)
+    기준_분기_코드: int
+    행정동_코드: int
+    서비스_업종_코드: str
+    sales_lag1_log: Optional[float] = None
+    sales_lag2_log: Optional[float] = None
+    sales_lag3_log: Optional[float] = None
+    sales_lag4_log: Optional[float] = None
+    sales_ma2: Optional[float] = None
+    sales_ma3: Optional[float] = None
+    sales_std2: Optional[float] = None
+    sales_std3: Optional[float] = None
+    sales_growth_1q: Optional[float] = None
+    sales_vs_ma3: Optional[float] = None
+    매출_증감률: Optional[float] = None
+    매출_대비_업종평균_비율: Optional[float] = None
+    점포_수: int
+    유사_업종_점포_수: int
+    franchise_ratio: Optional[float] = None
+    경쟁_밀도: Optional[float] = None
+    competition_ratio: Optional[float] = None
+    영역_면적: Optional[float] = None
+    floating_population_per_store: Optional[float] = None
+    유동인구_밀도: Optional[float] = None
+    young_pop_ratio: Optional[float] = None
+    weekend_pop_ratio: Optional[float] = None
+    log_총_유동인구_수: Optional[float] = None
+    월_평균_소득_금액: Optional[float] = None
+    음식_지출_비율: Optional[float] = None
+    유흥_지출_비율: Optional[float] = None
+    교육_지출_비율: Optional[float] = None
+    여가문화_지출_비율: Optional[float] = None
+    유사_업종_점포_수_lag1: Optional[float] = None
+    유사_업종_점포_수_변화_량: Optional[float] = None
+    폐업_률_변화_량: Optional[float] = None
+    총_유동인구_수_lag1: Optional[float] = None
+    유동인구_변화_량: Optional[float] = None
+
+
+
+# 매출 예측 출력
+class SalesOutput(BaseModel):
+    pred_sales: float               # 예측 월 매출 (원)
+    segment: int                    # K-means 구간 4개
+    confidence: str                 # 예측 신뢰도 : HIGH / LOW(구간 미만, 구간 초과)
+    message: Optional[str] = None   # 소규모/대규모 예외 시 안내 메시지


### PR DESCRIPTION
- KMeans + LightGBM + XBoost 앙상블 기반 매출 예측 API
- 소규모/고매출 특수상권 예외처리
- 사용한 설정, 모델 파일 git ignore에 추가(파일은 공유 드라이브 확인) # 예측 모델 파일(saved_sales_models)
report_pred_api/saved_sales_models/
- 팀 + 모델 실험 환경(colab)에 맞는 버전으로 requirements.txt 추가했습니다.

<img width="1449" height="1354" alt="스크린샷 2026-04-13 171034" src="https://github.com/user-attachments/assets/d66bf660-b6c5-4206-b6ba-ed08943b34cb" />