### PR TITLE
refactor: open ai api response 저장을 위해 schemas 구조 수정

### DIFF
--- a/report_pred_api/sales_predictor.py
+++ b/report_pred_api/sales_predictor.py
@@ -173,7 +173,8 @@ def predict_sales(data: SalesInput) -> SalesOutput:
                 segment=-1,
                 confidence="LOW",
                 top_sales_factors=None,
-                message="점포 수가 적어 예측 신뢰도가 낮습니다."
+                message="점포 수가 적어 예측 신뢰도가 낮습니다.",
+                sales_ai_response=None 
             )
 
         # 입력 전처리
@@ -228,7 +229,8 @@ def predict_sales(data: SalesInput) -> SalesOutput:
                 segment=segment,
                 confidence="LOW",
                 top_sales_factors=top_sales_factors,
-                message="예측 매출이 너무 낮아(100만원 미만) 신뢰도가 낮습니다."
+                message="예측 매출이 너무 낮아(100만원 미만) 신뢰도가 낮습니다.",
+                sales_ai_response=None 
             )
 
         if pred_sales > config["upper_bound"]:
@@ -237,7 +239,8 @@ def predict_sales(data: SalesInput) -> SalesOutput:
                 segment=segment,
                 confidence="LOW",
                 top_sales_factors=top_sales_factors,
-                message="고매출 특수상권(4억 이상)으로 예측 신뢰도가 낮습니다."
+                message="고매출 특수상권(4억 이상)으로 예측 신뢰도가 낮습니다.",
+                sales_ai_response=None 
             )
 
         # 정상 반환
@@ -246,7 +249,8 @@ def predict_sales(data: SalesInput) -> SalesOutput:
             segment=segment,
             confidence="HIGH",
             top_sales_factors=top_sales_factors,
-            message=None
+            message=None,
+            sales_ai_response=None       
         )
     except PredictionError:
         raise

--- a/report_pred_api/schemas.py
+++ b/report_pred_api/schemas.py
@@ -99,3 +99,4 @@ class SalesOutput(BaseModel):
     confidence: str                 # 예측 신뢰도 : HIGH / LOW(구간 미만, 구간 초과)
     top_sales_factors: Optional[list[dict]] = None  # feature importance TOP N 출력
     message: Optional[str] = None   # 소규모/대규모 예외 시 안내 메시지
+    sales_ai_response: Optional[str] = None # open ai 응답 저장


### PR DESCRIPTION
작업 내용
sales schemas에 sales_ai_response: Optional[str] = None # open ai 응답 저장 항목 추가
sales_predictor.py return에도 추가
Resolves: #55
